### PR TITLE
人物が全くいないフレームがあった場合にプログラムが落ちないようにする

### DIFF
--- a/src/track.py
+++ b/src/track.py
@@ -79,6 +79,16 @@ def track():
         for i in range(detected_person_length):
             keypointDict: dict[KeypointEnum, Keypoint] = {}
 
+            if (
+                boxes[i].id is None
+                or boxes[i].xyxy[0] is None
+                or boxes[i].conf[0] is None
+                or keypoints[i].xy[0] is None
+                or keypoints[i].conf[0] is None
+            ):
+                print(f"Frame {frame_num}, detected person {i} is None. Skipping.")
+                continue
+
             for keypointIndex in KeypointEnum:
                 keypointDict[keypointIndex] = Keypoint(
                     xy=keypoints[i].xy[0][keypointIndex.value].cpu().numpy(),

--- a/src/track.py
+++ b/src/track.py
@@ -135,7 +135,7 @@ def track():
                     "model": config.ModelName,
                     "video_path": config.InputPath,
                     "time_elapsed": ended_at - started_at,
-                    "max_person_count": max(person_id_set),
+                    "max_person_count": max(person_id_set, default=0),
                 },
                 f,
             )


### PR DESCRIPTION
誤検知によって、存在するはずのデータが取れない場合があるらしい
person_id等に存在チェックを追加し、存在しなかった場合はcontinueするようにした